### PR TITLE
shortened conference title in navbar

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -59,7 +59,9 @@ export class AppComponent implements OnInit {
     let dateStart = moment(conf.dateRange.start);
     let dateEnd = moment(conf.dateRange.end);
     let dateText = `${dateStart.format('MMM')} ${dateStart.format('D')}-${dateEnd.format('D')}, ${dateEnd.format('YYYY')}`
-    return `${conf.title} ~ ${dateText}`;
+    let title = `${conf.title}`;
+    // let title = `${conf.title} ~ ${dateText}`;
+    return title;
   }
 
 }


### PR DESCRIPTION
When logging in locally on smaller monitors, the navbar overlaps to a new line because the conference title is so long. This interferes with the app UI.

This fix shortens the title by removing the conference dates. This can be easily reverted back to the original if this is not desirable.