### PR TITLE
working fix for dashboard bug

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -27,7 +27,7 @@ let port = process.env.PORT || 3000;
 const mongoose = require('mongoose');
 mongoose.Promise = global.Promise;
 // TODO we need to change the below to use the mlab database used with heroku
-let mongoURI = 'mongodb://debugger:debugger@ds147799.mlab.com:47799/ccaw' || process.env.MONGODB_URI || 'mongodb://localhost/ccaw-app';
+let mongoURI = process.env.MONGODB_URI || 'mongodb://localhost/ccaw-app';
 mongoose.connect(mongoURI);
 
 /** True = get response details on served node modules **/

--- a/server/server.js
+++ b/server/server.js
@@ -25,8 +25,9 @@ let port = process.env.PORT || 3000;
 
 /*  Configure Connection to MongoDB  **/
 const mongoose = require('mongoose');
+mongoose.Promise = global.Promise;
 // TODO we need to change the below to use the mlab database used with heroku
-let mongoURI = process.env.MONGODB_URI || 'mongodb://localhost/ccaw-app';
+let mongoURI = 'mongodb://debugger:debugger@ds147799.mlab.com:47799/ccaw' || process.env.MONGODB_URI || 'mongodb://localhost/ccaw-app';
 mongoose.connect(mongoURI);
 
 /** True = get response details on served node modules **/

--- a/src/app/shared/speaker.service.ts
+++ b/src/app/shared/speaker.service.ts
@@ -194,7 +194,8 @@ export class SpeakerService {
     speakers.mainPresenter = this.getSpeaker(speakerIdList.mainPresenter);
     speakers.coPresenters = [];
     speakerIdList.coPresenters.forEach(coPresId => {
-      speakers.coPresenters.push(this.getSpeaker(coPresId));
+      let coPresenter = this.getSpeaker(coPresId);
+      if (coPresenter) speakers.coPresenters.push(coPresenter);
     });
     return speakers;
   }

--- a/src/app/user/dashboard/dashboard.component.html
+++ b/src/app/user/dashboard/dashboard.component.html
@@ -1,6 +1,6 @@
 <div class="container" [class.page-transition]="transitionService.isTransitioning()">
   <div class="row">
-    <h1 class="text-center">Hello, {{speaker.nameFirst}}!</h1>
+    <h1 class="text-center">Hello, {{speaker?.nameFirst}}!</h1>
     <p class="text-center">Please complete your speaker account by updating your profile and proposal(s).<br/> Contact Brooke Meyer at <a (click)="email()" class="contact">bmeyer@genesisshelter.org</a> or <a (click)="call()" class="contact">214-389-7733</a> if you have any questions or issues.</p>
     <button class="btn btn-primary center-block" (click)="copresLinkJump()">Add co-presenters</button>
   </div>
@@ -91,7 +91,7 @@
                 <div><i>Copresenters:</i></div>
                 <div *ngFor="let coPres of speakerService.getSpeakerList(session.speakers).coPresenters">
                   <i class="fa fa-ban delete" (click)="removeCopres(session._id, coPres._id)"></i>
-                  {{ coPres.nameFirst }} {{ coPres.nameLast }}
+                  {{ coPres?.nameFirst }} {{ coPres?.nameLast }}
                 </div>
               </div>
               <div class="space-top-sm"><b>Currently Scheduled for: </b></div>
@@ -114,7 +114,7 @@
                 <div><b>Copresenters:</b></div>
                 <div *ngFor="let coPres of speakerService.getSpeakerList(session.speakers).coPresenters">
                   <i *ngIf="session.speakers?.mainPresenter === speaker._id" class="fa fa-ban delete" (click)="removeCopres(session._id, coPres._id)"></i>
-                  {{ coPres.nameFirst }} {{ coPres.nameLast }}
+                  {{ coPres?.nameFirst }} {{ coPres?.nameLast }}
                 </div>
               </div>
               <div class="divider-s"></div>
@@ -152,7 +152,7 @@
           <select #speakers class="form-control" id="speakers">
             <option *ngFor="let speaker of (speakerService.unArchivedSpeakers | async)"
                     [value]="speaker._id">
-              {{ speaker.nameLast }}, {{ speaker.nameFirst }}
+              {{ speaker?.nameLast }}, {{ speaker?.nameFirst }}
             </option>
           </select>
           <button class="btn btn-primary" (click)="addCopres(sessions.value, speakers.value)">Add Co-presenter</button>

--- a/src/app/user/dashboard/dashboard.component.ts
+++ b/src/app/user/dashboard/dashboard.component.ts
@@ -214,7 +214,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     if (this.isResponseFormNeeded()) return false;
     if (!this.speaker.headshot) return false;
     if (this.needsHandouts()) return false;
-    if (this.speaker.responseForm && !this.speaker.responseForm.w9) return false;
     if (this.speaker.adminUploads.length > 0) return false;
     if (this.otherAdminAllUls.length > 0) return false;
     return true;


### PR DESCRIPTION
This is a working fix for the dashboard bug. By including Angular's Safe Navigation Operator (`?`) on several fields in the Dashboard template, the problem seems to be fixed. This is related to fetching data in async operations and the template trying to load before the data is ready, resulting in certain fields being `undefined`. I don't know why this would occur for certain users and not others consistently... but either way this seems to be a working fix which I've verified using Carrie Paschall's account. We can improve upon this if we find there are more problems later.

This also modifies the **Action Required** section to remove the requirement for a w9 form.

There is also a modification for the function that fetches co-presenters. This was returning some empty presenters so there is just logic to avoid this now.

Finally, this also adds a change to avoid the mongoose Promise deprecation warning.